### PR TITLE
Fix data being required in PATCH requests

### DIFF
--- a/keygen-openapi.yml
+++ b/keygen-openapi.yml
@@ -79,6 +79,7 @@ paths:
                                 `000000`.
                   required:
                     - type
+                    - attributes
       responses:
         "201":
           description: Token generated successfully
@@ -428,6 +429,9 @@ paths:
                           additionalProperties: true
                   required:
                     - type
+                    - attributes
+              required:
+                - data
       responses:
         "200":
           description: Product updated successfully
@@ -504,6 +508,7 @@ paths:
                           description: The timestamp for when the token expires.
                   required:
                     - type
+                    - attributes
       responses:
         "200":
           description: Product token generated successfully
@@ -686,6 +691,9 @@ paths:
                           additionalProperties: true
                   required:
                     - type
+                    - attributes
+              required:
+                - data
       responses:
         "200":
           description: Entitlement updated successfully
@@ -912,6 +920,9 @@ paths:
                           additionalProperties: true
                   required:
                     - type
+                    - attributes
+              required:
+                - data
       responses:
         "200":
           description: Group updated successfully
@@ -1595,6 +1606,9 @@ paths:
                           additionalProperties: true
                   required:
                     - type
+                    - attributes
+              required:
+                - data
       responses:
         "200":
           description: Policy updated successfully
@@ -2079,28 +2093,11 @@ paths:
                           type: object
                           description: Object containing user metadata.
                           additionalProperties: true
-                    relationships:
-                      type: object
-                      properties:
-                        group:
-                          type: object
-                          description: The group the user belongs to.
-                          properties:
-                            data:
-                              type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum: [groups]
-                                id:
-                                  type: string
-                              required:
-                                - type
-                                - id
-                          required:
-                            - data
                   required:
                     - type
+                    - attributes
+              required:
+                - data
       responses:
         "200":
           description: User updated successfully
@@ -2361,6 +2358,7 @@ paths:
                           description: The timestamp for when the token expires.
                   required:
                     - type
+                    - attributes
       responses:
         "200":
           description: User token generated successfully
@@ -2743,49 +2741,63 @@ paths:
               title: UpdateLicenseRequest
               type: object
               properties:
-                name:
-                  type: string
-                  description: The name of the license.
-                expiry:
-                  type:
-                    - string
-                    - "null"
-                  format: date-time
-                  description: When the license will expire.
-                maxMachines:
-                  type:
-                    - integer
-                    - "null"
-                  format: int64
-                  description: The maximum number of machines the license can have associated with it.
-                maxProcesses:
-                  type:
-                    - integer
-                    - "null"
-                  format: int64
-                  description: The maximum number of machine processes the license can have associated with it.
-                maxCores:
-                  type:
-                    - integer
-                    - "null"
-                  format: int64
-                  description: The maximum number of machine CPU cores the license can have associated with it.
-                maxUses:
-                  type:
-                    - integer
-                    - "null"
-                  format: int64
-                  description: The maximum number of uses the license is allowed to have.
-                protected:
-                  type: boolean
-                  description: Whether or not the license is protected.
-                suspended:
-                  type: boolean
-                  description: Whether or not the license is suspended.
-                metadata:
+                data:
                   type: object
-                  description: Object containing license metadata.
-                  additionalProperties: true
+                  properties:
+                    type:
+                      type: string
+                      enum: [licenses]
+                    attributes:
+                      type: object
+                      properties:
+                        name:
+                          type: string
+                          description: The name of the license.
+                        expiry:
+                          type:
+                            - string
+                            - "null"
+                          format: date-time
+                          description: When the license will expire.
+                        maxMachines:
+                          type:
+                            - integer
+                            - "null"
+                          format: int64
+                          description: The maximum number of machines the license can have associated with it.
+                        maxProcesses:
+                          type:
+                            - integer
+                            - "null"
+                          format: int64
+                          description: The maximum number of machine processes the license can have associated with it.
+                        maxCores:
+                          type:
+                            - integer
+                            - "null"
+                          format: int64
+                          description: The maximum number of machine CPU cores the license can have associated with it.
+                        maxUses:
+                          type:
+                            - integer
+                            - "null"
+                          format: int64
+                          description: The maximum number of uses the license is allowed to have.
+                        protected:
+                          type: boolean
+                          description: Whether or not the license is protected.
+                        suspended:
+                          type: boolean
+                          description: Whether or not the license is suspended.
+                        metadata:
+                          type: object
+                          description: Object containing license metadata.
+                          additionalProperties: true
+                  required:
+                    - type
+                    - attributes
+              required:
+                - data
       responses:
         "200":
           description: License updated successfully
@@ -3549,6 +3561,7 @@ paths:
                           description: The maximum number of machine deactivations the token is allowed to perform.
                   required:
                     - type
+                    - attributes
       responses:
         "200":
           description: License token generated successfully
@@ -4177,47 +4190,11 @@ paths:
                         metadata:
                           type: object
                           description: Object containing machine metadata.
-                    relationships:
-                      type: object
-                      properties:
-                        license:
-                          type: object
-                          description: The license the machine is for.
-                          properties:
-                            data:
-                              type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum: [licenses]
-                                id:
-                                  type: string
-                              required:
-                                - type
-                                - id
-                          required:
-                            - data
-                        group:
-                          type: object
-                          description: The group the machine belongs to.
-                          properties:
-                            data:
-                              type:
-                                - object
-                                - "null"
-                              properties:
-                                type:
-                                  type: string
-                                  enum: [groups]
-                                id:
-                                  type: string
-                              required:
-                                - type
-                                - id
-                          required:
-                            - data
                   required:
                     - type
+                    - attributes
+              required:
+                - data
       responses:
         "200":
           description: Machine updated successfully
@@ -4669,28 +4646,11 @@ paths:
                           type: object
                           description: Object containing process metadata.
                           additionalProperties: true
-                    relationships:
-                      type: object
-                      properties:
-                        machine:
-                          type: object
-                          description: The machine the process is for.
-                          properties:
-                            data:
-                              type: object
-                              properties:
-                                type:
-                                  type: string
-                                  enum: [machines]
-                                id:
-                                  type: string
-                              required:
-                                - type
-                                - id
-                          required:
-                            - data
                   required:
                     - type
+                    - attributes
+              required:
+                - data
       responses:
         "200":
           description: Process updated successfully


### PR DESCRIPTION
This PR aligns the spec of PATCH requests to what the API actually expects (if `data` is provided, then `attributes` are required).

Also, it fixes the update license endpoint's payload to match the API's.